### PR TITLE
Add cli interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # daten
+
+## about package
+* based on stack
+* easy to use via stack
+```
+stack test
+stack build
+stack run -- --help
+```

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -68,5 +68,6 @@ main = do
     opts =
       info
         (appOpts <**> helper)
-        (fullDesc <> progDesc "Upgrade for TARGET" <>
-         header "sysup - a command for upgrade")
+        (fullDesc <>
+         progDesc "generate joined string filled dates from start to end" <>
+         header "daten -- generate data n list")

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,72 @@
 module Main where
 
-import Lib
+import           Data.Semigroup      ((<>))
+import           Data.Time.Calendar
+import           Data.Time.Clock
+import           Data.Time.Format
+import           Daten               as D
+import           Options.Applicative
+
+data AppOpts = AppOpts
+  { start   :: String
+  , end     :: String
+  , format  :: String
+  , joinStr :: String
+  } deriving (Show)
+
+startParser :: Parser String
+startParser =
+  strOption
+    (long "start" <> short 's' <>
+     help "Start date with format 'yyyy-mm-dd' or today" <>
+     showDefault <>
+     value "today" <>
+     metavar "START")
+
+endParser :: Parser String
+endParser =
+  strOption
+    (long "end" <> short 'e' <>
+     help "End date with format 'yyyy-mm-dd' or today" <>
+     showDefault <>
+     value "today" <>
+     metavar "END")
+
+formatParser :: Parser String
+formatParser =
+  strOption
+    (long "format" <> short 'f' <> help "format to print" <> showDefault <>
+     value "%Y-%m-%d" <>
+     metavar "FORMAT")
+
+joinStrParser :: Parser String
+joinStrParser =
+  strOption
+    (long "join_str" <> short 'j' <> help "Join string" <> showDefault <>
+     value "','" <>
+     metavar "JOIN_STR")
+
+--appOpts :: Parser AppOpts
+appOpts =
+  AppOpts <$> startParser <*> endParser <*> formatParser <*> joinStrParser
 
 main :: IO ()
-main = someFunc
+main = do
+  o <- execParser opts
+  t <- getCurrentTime
+  let s = todayOr (start o) t
+  let e = todayOr (end o) t
+  putStrLn $ D.join (joinStr o) (D.Daten s e (format o))
+  where
+    utcToGregorian = toGregorian . utctDay
+    strToGregorian s =
+      (read . take 4 $ s, read . take 2 . drop 5 $ s, read . drop 8 $ s)
+    todayOr x t =
+      if x == "today"
+        then utcToGregorian t
+        else strToGregorian x
+    opts =
+      info
+        (appOpts <**> helper)
+        (fullDesc <> progDesc "Upgrade for TARGET" <>
+         header "sysup - a command for upgrade")

--- a/package.yaml
+++ b/package.yaml
@@ -22,6 +22,7 @@ description:         Please see the README on GitHub at <https://github.com/ynis
 dependencies:
 - base >= 4.7 && < 5
 - time
+- optparse-applicative
 
 library:
   source-dirs: src

--- a/src/Daten.hs
+++ b/src/Daten.hs
@@ -1,30 +1,35 @@
-module Daten 
-  (
-  DatenDate,
-  DatenFormat,
-  Daten(..),
-  toFormatteds,
-  join
+module Daten
+  ( DatenDate
+  , DatenFormat
+  , Daten(..)
+  , toFormatteds
+  , join
   ) where
 
-import Data.Time.Calendar
-import Data.Time.Format
-import Data.List
+import           Data.List
+import           Data.Time.Calendar
+import           Data.Time.Format
 
 type DatenDate = (Integer, Int, Int)
+
 type DatenFormat = String
 
-data Daten = Daten DatenDate DatenDate DatenFormat deriving(Show)
+data Daten =
+  Daten DatenDate
+        DatenDate
+        DatenFormat
+  deriving (Show)
 
-toFormatteds d@(Daten start end tpl) = map showWithFormat $ dates start end 
+toFormatteds d@(Daten start end tpl) = map showWithFormat $ dates start end
   where
     showWithFormat = formatTime defaultTimeLocale tpl
 
-dates (sy, sm, sd) (ey, em, ed) = takeWhile (<= endDay) . map addDaysToStart $ [0..]
+dates (sy, sm, sd) (ey, em, ed) =
+  takeWhile (<= endDay) . map addDaysToStart $ [0 ..]
   where
     startDay = fromGregorian sy sm sd
-    endDay = fromGregorian ey em ed 
+    endDay = fromGregorian ey em ed
     addDays' = flip addDays
     addDaysToStart = addDays' startDay
 
-join x d = "'" ++ (intercalate x $ toFormatteds d) ++ "'"
+join x d = "'" ++ intercalate x (toFormatteds d) ++ "'"

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -1,6 +1,0 @@
-module Lib
-    ( someFunc
-    ) where
-
-someFunc :: IO ()
-someFunc = putStrLn "someFunc"

--- a/test/DatenSpec.hs
+++ b/test/DatenSpec.hs
@@ -25,7 +25,7 @@ spec = do
       let cases =
             [ ( ("',\n'", (2019, 1, 1), (2019, 1, 2), "%Y-%m-%d")
               , "'2019-01-01',\n'2019-01-02'")
-              ]
+            ]
       mapM_
         (\((x1, x2, x3, x4), expected) ->
            join x1 (Daten x2 x3 x4) `shouldBe` expected)


### PR DESCRIPTION
made cli interface
```
stack run -- --help
```
```
daten -- generate data n list

Usage: daten-exe [-s|--start START] [-e|--end END] [-f|--format FORMAT]
                 [-j|--join_str JOIN_STR]
  generate joined string filled dates from start to end

Available options:
  -s,--start START         Start date with format 'yyyy-mm-dd' or
                           today (default: "today")
  -e,--end END             End date with format 'yyyy-mm-dd' or
                           today (default: "today")
  -f,--format FORMAT       format to print (default: "%Y-%m-%d")
  -j,--join_str JOIN_STR   Join string (default: "','")
  -h,--help                Show this help text
```